### PR TITLE
Fix min supported SDK version for Example App

### DIFF
--- a/Example/app/build.gradle
+++ b/Example/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "com.gladly.samplechatapp"
-        minSdkVersion 17
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
## What
Bump the min supported Android SDK version of the Example App to match the Android Chat-SDK min supported SDK version.


## Why
To fix build error and have min supported version match our documentation:
https://developer.gladly.com/android-sdk/#requirements (API 21 and above)

## Who
@mrbaker4 
@dmalmkvist 