### PR TITLE
Fix saved login in Example app

### DIFF
--- a/Example/app/src/main/java/com/gladly/samplechatapp/GladlyChatUtils.kt
+++ b/Example/app/src/main/java/com/gladly/samplechatapp/GladlyChatUtils.kt
@@ -121,6 +121,18 @@ object GladlyChatUtils {
         }
     }
 
+    fun isUserSet(context: Context): Boolean {
+        context.getSharedPreferences(SHARED_PREF_NAME, Context.MODE_PRIVATE).apply {
+            val currEmail = getString(SHARED_PREF_NAME_CURRENT_EMAIL_LOGIN, "")
+            val currName = getString(SHARED_PREF_NAME_CURRENT_NAME_LOGIN, "")
+
+            if (currEmail == "" || currName == "") {
+                return false
+            }
+            return true
+        }
+    }
+
     private const val SHARED_PREF_NAME = "gladly.chat.utils.shared.prefs"
     private const val SHARED_PREF_NAME_CURRENT_EMAIL_LOGIN = "gladly.chat.utils.shared.prefs.email"
     private const val SHARED_PREF_NAME_CURRENT_NAME_LOGIN = "gladly.chat.utils.shared.prefs.name"

--- a/Example/app/src/main/java/com/gladly/samplechatapp/MainActivity.kt
+++ b/Example/app/src/main/java/com/gladly/samplechatapp/MainActivity.kt
@@ -24,9 +24,11 @@ class MainActivity : AppCompatActivity() {
         openChat.setOnClickListener {
             Log.d(TAG, "Showing Chat...")
 
-            GladlyChatUtils.loginAs(this,
-                "john.connor@future.com",
-                "John Connor")
+            if (!GladlyChatUtils.isUserSet(this)) {
+                GladlyChatUtils.loginAs(this,
+                    "john.connor@future.com",
+                    "John Connor")
+            }
 
             GladlyChatUtils.showChat(this)
         }


### PR DESCRIPTION
## What
- Use the saved login if it exists

Before: (Setting custom user works for initial chat session but user is unable to re-open the chat window using the 'Open Chat' button)
![example_app_saved_user_bug](https://user-images.githubusercontent.com/4493081/124334921-76fa1e00-db4d-11eb-8d7e-109a021734b9.gif)

After: Using the 'Open Chat' button with an existing user will default to using the existing user. Chat history will now load for all users - not just the default 'John Connor' user.
![example_app_saved_user_fix](https://user-images.githubusercontent.com/4493081/124334919-73ff2d80-db4d-11eb-9edc-d465e5f9f875.gif)



## Why
- To be able to navigate back to the chat session after logging in as a new user

## Testing
Using the Example App with a valid appID, click 'Open Chat' and verify that you are signed in as 'John Connor' as the default user. 
Navigate back to the main screen and click 'Login as a new user' and set email + name. Start a chat session and then navigate back to the main screen. Click 'Open Chat' and verify that the saved user and their chat history still exists.

## Who
@dmalmkvist 
@mrbaker4 